### PR TITLE
fix(home-screen-tests): Fix HomeScreenTest due to the component's par…

### DIFF
--- a/app/src/androidTest/java/com/enriqueajin/newsapp/presentation/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/enriqueajin/newsapp/presentation/home/HomeScreenTest.kt
@@ -4,13 +4,11 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.paging.PagingData
 import com.enriqueajin.newsapp.util.Constants.CATEGORIES
 import com.enriqueajin.newsapp.util.DummyDataProvider
 import com.enriqueajin.newsapp.util.TestTags.ALL_ARTICLES_ARTICLES_LIST
 import com.enriqueajin.newsapp.util.TestTags.HOME
 import com.enriqueajin.newsapp.util.TestTags.HOME_ARTICLES_BY_CATEGORY
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 
@@ -22,10 +20,12 @@ class HomeScreenTest {
     fun checkHomeScreenDisplayed() {
         composeTestRule.setContent {
             HomeScreen(
-                event = {},
                 localState = HomeLocalState(),
                 uiState = HomeUiState.Loading,
-                articlesStateFlow = MutableStateFlow(PagingData.empty()),
+                articlesByCategory = DummyDataProvider.getFakeLazyPagingItems(data = DummyDataProvider.getAllNewsItems()),
+                onCollectArticlesByCategory = {},
+                onCategoryChange = {},
+                onCategoryScrollPositionChanged = {},
                 onSeeAllClicked = {},
                 onItemClicked = {}
             )
@@ -38,14 +38,15 @@ class HomeScreenTest {
         val state = HomeUiState.Success(
             latestArticles = DummyDataProvider.getLatestNewsItems(),
             articlesByKeyword = DummyDataProvider.getAllNewsItems(),
-            keyword = "Recipes"
         )
         composeTestRule.setContent {
             HomeScreen(
-                event = {},
                 localState = HomeLocalState(category = "All"),
                 uiState = state,
-                articlesStateFlow = MutableStateFlow(PagingData.empty()),
+                articlesByCategory = DummyDataProvider.getFakeLazyPagingItems(data = DummyDataProvider.getAllNewsItems()),
+                onCollectArticlesByCategory = {},
+                onCategoryChange = {},
+                onCategoryScrollPositionChanged = {},
                 onSeeAllClicked = {},
                 onItemClicked = {}
             )
@@ -58,16 +59,17 @@ class HomeScreenTest {
         val state = HomeUiState.Success(
             latestArticles = DummyDataProvider.getLatestNewsItems(),
             articlesByKeyword = DummyDataProvider.getAllNewsItems(),
-            keyword = "Recipes"
         )
         composeTestRule.setContent {
             HomeScreen(
-                event = {},
                 localState = HomeLocalState(category = "All"),
                 uiState = state,
-                articlesStateFlow = MutableStateFlow(PagingData.empty()),
+                articlesByCategory = DummyDataProvider.getFakeLazyPagingItems(data = DummyDataProvider.getAllNewsItems()),
+                onCollectArticlesByCategory = {},
+                onCategoryChange = {},
+                onCategoryScrollPositionChanged = {},
                 onSeeAllClicked = {},
-                onItemClicked = {}
+                onItemClicked = {},
             )
         }
         composeTestRule.onNodeWithTag(HOME_ARTICLES_BY_CATEGORY).assertIsNotDisplayed()
@@ -82,16 +84,17 @@ class HomeScreenTest {
         val state = HomeUiState.Success(
             latestArticles = DummyDataProvider.getLatestNewsItems(),
             articlesByKeyword = DummyDataProvider.getAllNewsItems(),
-            keyword = "Recipes"
         )
         composeTestRule.setContent {
             HomeScreen(
-                event = {},
                 localState = HomeLocalState(category = category),
                 uiState = state,
-                articlesStateFlow = MutableStateFlow(PagingData.empty()),
+                articlesByCategory = DummyDataProvider.getFakeLazyPagingItems(data = DummyDataProvider.getAllNewsItems()),
+                onCollectArticlesByCategory = {},
+                onCategoryChange = {},
+                onCategoryScrollPositionChanged = {},
                 onSeeAllClicked = {},
-                onItemClicked = {}
+                onItemClicked = {},
             )
         }
         composeTestRule.onNodeWithTag(HOME_ARTICLES_BY_CATEGORY).assertIsDisplayed()
@@ -106,16 +109,17 @@ class HomeScreenTest {
         val state = HomeUiState.Success(
             latestArticles = DummyDataProvider.getLatestNewsItems(),
             articlesByKeyword = DummyDataProvider.getAllNewsItems(),
-            keyword = "Recipes"
         )
         composeTestRule.setContent {
             HomeScreen(
-                event = {},
                 localState = HomeLocalState(category = category),
                 uiState = state,
-                articlesStateFlow = MutableStateFlow(PagingData.empty()),
+                articlesByCategory = DummyDataProvider.getFakeLazyPagingItems(data = DummyDataProvider.getAllNewsItems()),
+                onCollectArticlesByCategory = {},
+                onCategoryChange = {},
+                onCategoryScrollPositionChanged = {},
                 onSeeAllClicked = {},
-                onItemClicked = {}
+                onItemClicked = {},
             )
         }
         composeTestRule.onNodeWithTag(ALL_ARTICLES_ARTICLES_LIST).assertIsNotDisplayed()

--- a/app/src/androidTest/java/com/enriqueajin/newsapp/presentation/home/components/CategoryGroupTest.kt
+++ b/app/src/androidTest/java/com/enriqueajin/newsapp/presentation/home/components/CategoryGroupTest.kt
@@ -28,11 +28,11 @@ class CategoryGroupTest {
     fun checkCategoryGroupIsScrollable() {
         composeTestRule.setContent {
             CategoryGroup(
-                event = {},
                 scrollPosition = 0,
                 categories = categories,
                 selected = selected,
-                onChipSelected = { category -> selected = category }
+                onChipSelected = { category -> selected = category },
+                onCategoryScrollPositionChanged = {}
             )
         }
         composeTestRule.onNodeWithTag(CATEGORY_GROUP_LAZY_ROW).assert(hasScrollAction())
@@ -43,11 +43,11 @@ class CategoryGroupTest {
         composeTestRule.setContent {
             NewsAppTheme {
                 CategoryGroup(
-                    event = {},
                     scrollPosition = 0,
                     categories = categories,
                     selected = selected,
-                    onChipSelected = { category -> selected = category }
+                    onChipSelected = { category -> selected = category },
+                    onCategoryScrollPositionChanged = {}
                 )
             }
         }
@@ -77,11 +77,11 @@ class CategoryGroupTest {
         composeTestRule.setContent {
             NewsAppTheme {
                 CategoryGroup(
-                    event = {},
                     scrollPosition = 0,
                     categories = categories,
                     selected = selected,
-                    onChipSelected = { category -> selected = category }
+                    onChipSelected = { category -> selected = category },
+                    onCategoryScrollPositionChanged = {}
                 )
             }
         }

--- a/app/src/main/java/com/enriqueajin/newsapp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/enriqueajin/newsapp/presentation/home/HomeScreen.kt
@@ -6,11 +6,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.enriqueajin.newsapp.domain.model.Article
 import com.enriqueajin.newsapp.presentation.home.components.AllArticles
 import com.enriqueajin.newsapp.presentation.home.components.ArticlesByCategory
@@ -29,10 +34,13 @@ internal fun HomeRoute(
 ) {
     val localState by homeViewModel.localState.collectAsStateWithLifecycle()
     val uiState by homeViewModel.uiState.collectAsStateWithLifecycle()
+    var articlesByCategory by rememberSaveable { mutableStateOf<LazyPagingItems<Article>?>(null) }
 
     HomeScreen(
         localState = localState,
         uiState = uiState,
+        articlesByCategory = articlesByCategory,
+        onCollectArticlesByCategory = { articlesByCategory = homeViewModel.newsByCategory.collectAsLazyPagingItems() },
         onCategoryChange = { category -> homeViewModel.localState.update { it.copy(category = category) }},
         onCategoryScrollPositionChanged = { pos -> homeViewModel.localState.update { it.copy(categoriesScrollPosition = pos) } },
         onItemClicked = onItemClicked,
@@ -44,6 +52,8 @@ internal fun HomeRoute(
 fun HomeScreen(
     localState: HomeLocalState,
     uiState: HomeUiState,
+    articlesByCategory: LazyPagingItems<Article>?,
+    onCollectArticlesByCategory: @Composable () -> Unit,
     onCategoryChange: (String) -> Unit,
     onCategoryScrollPositionChanged: (Int) -> Unit,
     onSeeAllClicked: (String) -> Unit,
@@ -77,6 +87,8 @@ fun HomeScreen(
                     ArticlesByCategory(
                         modifier = Modifier.testTag(HOME_ARTICLES_BY_CATEGORY),
                         category = localState.category,
+                        articles = articlesByCategory,
+                        onCollectArticlesByCategory = onCollectArticlesByCategory,
                         onItemClicked = onItemClicked
                     )
                 }
@@ -96,6 +108,8 @@ fun HomePreview() {
     HomeScreen(
         localState = HomeLocalState(),
         uiState = state,
+        articlesByCategory = DummyDataProvider.getFakeLazyPagingItems(data = DummyDataProvider.getAllNewsItems()),
+        onCollectArticlesByCategory = {},
         onCategoryChange = {},
         onCategoryScrollPositionChanged = {},
         onSeeAllClicked = {},

--- a/app/src/main/java/com/enriqueajin/newsapp/presentation/home/components/ArticlesByCategory.kt
+++ b/app/src/main/java/com/enriqueajin/newsapp/presentation/home/components/ArticlesByCategory.kt
@@ -5,27 +5,29 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.LazyPagingItems
 import com.enriqueajin.newsapp.domain.model.Article
 import com.enriqueajin.newsapp.presentation.PagingStateHandler
-import com.enriqueajin.newsapp.presentation.home.HomeViewModel
 
 @Composable
 fun ArticlesByCategory(
-    homeViewModel: HomeViewModel = hiltViewModel(),
     modifier:  Modifier,
     category: String,
+    articles: LazyPagingItems<Article>?,
+    onCollectArticlesByCategory: @Composable () -> Unit,
     onItemClicked: (Article) -> Unit
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         // Reset LazyPagingItems state when category changes
         key(category) {
-            val articles = homeViewModel.newsByCategory.collectAsLazyPagingItems()
-            PagingStateHandler(
-                articles = articles,
-                onItemClicked = { article -> onItemClicked(article) }
-            )
+            onCollectArticlesByCategory()
+
+            if (articles != null) {
+                PagingStateHandler(
+                    articles = articles,
+                    onItemClicked = onItemClicked
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
…ams change. Add 'articles' and 'onCollectArticlesByCategory' to ArticlesByCategory to change the approach in which the LazyPagingItems are collected in order to inject HomeViewModel again through hiltViewModel() since it was causing an error. Fix CategoryGroupTest due to change in component's params as well.